### PR TITLE
Changed Class Names, Shortened `torah.py` by 43 Lines, And More!

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,18 @@ No instalation for now!
 
 ```python
 # To return a verse(s) info inside the surah(Chapter)
-from hollybooks import quran
+from hollybooks import Surah
 
-surah=quran.Surah.request(112) #'112' is the chapter and request is for sync function to make it async replace request to async_request()
+surah=Surah.request(112) #'112' is the chapter and request is for sync function to make it async replace request to async_request()
 print(surah.request_ayahs())
 #return the verses in a list 
 
 #===============================================================================================================================
 
 # To return a bible verse's info
-from hollybooks import bible
+from hollybooks import Bible
 
-bible_verses=bible.Chapter.request( #request is for sync function to make it async replace request to async_request()
+bible_verses=Bible.request(  #request is for sync function to make it async replace request to async_request()
     "2 Corinthians", chapter=4,
     starting_verse=16, ending_verse=18
 )  # this gets the info of 2 Corinthians 4:16-18
@@ -36,9 +36,9 @@ for verse in bible_verses.verses:
 	
 #===============================================================================================================================
 
-from hollybooks import torah
+from hollybooks import Torah
 
-torah_verses=torah.Chapter.request( #request is for sync function to make it async replace request to async_request()
+torah_verses=Torah.request(  #request is for sync function to make it async replace request to async_request()
     "Genesis", chapter=1,
     starting_verse=1, ending_verse=10
 )  # this gets the info of Genesis 1:1-10

--- a/hollybooks/bible.py
+++ b/hollybooks/bible.py
@@ -1,130 +1,112 @@
-__all__ = ("ApiError", "NotFound", "ChapterVerse", "Chapter", "TorahOnly")
+__all__ = ("ApiError", "NotFound", "ChapterVerse", "Bible")
 
 
 class ApiError(Exception):
-	def __init__(self, status: int, msg: str) -> None:
-		super().__init__(f"Api has an error, return code: {status}.\n{msg}")
+    def __init__(self, status: int, msg: str) -> None:
+        super().__init__(f"Api has an error, return code: {status}.\n{msg}")
 
 
 class NotFound(Exception):
-	def __init__(self, book: str, chapter: int, verse: str) -> None:
-		super().__init__(
-			f"Book {book}, Chapter {chapter}, Verse(s) {verse} Wasn't Found."
-		)
+    def __init__(self, book: str, chapter: int, verse: str) -> None:
+        super().__init__(
+            f"Book {book}, Chapter {chapter}, Verse(s) {verse} Wasn't Found."
+        )
 
-class TorahOnly(Exception):
-	def __init__(self, book: str) -> None:
-		super().__init__(
-			f"The book {book} wasn't found because its available only on torah"
-		)
 
 def _build_verse(start: int, end: int = None) -> str:
-	return f"{start}{f'-{end}' if end else ''}"
+    return f"{start}{f'-{end}' if end else ''}"
 
 
 def _build_citation(book: str, chapter: int, verse: str) -> str:
-	return f"{book} {chapter}:{verse}"
+    return f"{book} {chapter}:{verse}"
 
 
 class ChapterVerse:
-	def __init__(self, verse: dict) -> None:
-		del verse["book_id"]
+    def __init__(self, verse: dict) -> None:
+        del verse["book_id"]
 
-		for key, val in verse.items():
-			setattr(self, key, val)
+        for key, val in verse.items():
+            setattr(self, key, val)
 
-	def __str__(self) -> str:
-		return self.text
+    def __str__(self) -> str:
+        return self.text
 
-	@property
-	def citation(self) -> str:
-		return _build_citation(self.book_name, self.chapter, self.verse)
+    @property
+    def citation(self) -> str:
+        return _build_citation(self.book_name, self.chapter, self.verse)
 
 
-class Chapter:
-	def __init__(self, book: str) -> None:
-		self.book = book
+class Bible:
+    def __init__(self, book: str) -> None:
+        self.book = book
 
-	@classmethod
-	def request(
-		cls, 
-		book: str, 
-		*, 
-		chapter: int, 
-		starting_verse: int, 
-		ending_verse: int = None
-	):
-		if book.lower() in ['genesis', 'exodus', 'leviticus', 'numbers', 'deuteronomy']:
-			raise TorahOnly(book)
+    @classmethod
+    def request(
+        cls, book: str, *, chapter: int, starting_verse: int, ending_verse: int = None
+    ):
+        try:
+            import requests
+        except ImportError:
+            raise ImportError(
+                "Please Install the requests module if you want to make a sync request."
+            )
 
-		try:
-			import requests
-		except ImportError:
-			raise ImportError(
-				"Please Install the requests module if you want to make a sync request."
-			)
+        self = cls(book)
+        verse = _build_verse(starting_verse, ending_verse)
 
-		self = cls(book)
-		verse = _build_verse(starting_verse, ending_verse)
+        self.request = requests.get(f"https://bible-api.com/{book}+{chapter}:{verse}")
+        if self.request.status_code == 404:
+            raise NotFound(book, chapter, verse)
+        elif self.request.status_code > 202:
+            raise ApiError(
+                self.request.status_code, self.request.json().get("error", "")
+            )
 
-		self.request = requests.get(
-		f"https://bible-api.com/{book}+{chapter}:{verse}"
-		)
-		if self.request.status_code == 404:
-			raise NotFound(book, chapter, verse)
-		elif self.request.status_code > 202:
-			raise ApiError(
-				self.request.status_code, self.request.json().get("error", "")
-			)
+        self.json = self.request.json()
+        self.verses = [ChapterVerse(i) for i in self.json["verses"]]
 
-		self.json = self.request.json()
-		self.verses = [ChapterVerse(i) for i in self.json["verses"]]
+        return self
 
-		return self
+    @classmethod
+    async def async_request(
+        cls,
+        book: str,
+        *,
+        chapter: int,
+        starting_verse: int,
+        ending_verse: int = None,
+        loop=None,
+    ):
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError(
+                "Please Install the aiohttp module if you want to make an async request."
+            )
 
-	@classmethod
-	async def async_request(
-		cls,
-		book: str,
-		*,
-		chapter: int,
-		starting_verse: int,
-		ending_verse: int = None,
-		loop=None,
-	):
-		if book.lower() in ['genesis', 'exodus', 'leviticus', 'numbers', 'deuteronomy']:
-			raise TorahOnly(book)
+        self = cls(book)
+        verse = _build_verse(starting_verse, ending_verse)
 
-		try:
-			import aiohttp
-		except ImportError:
-			raise ImportError(
-				"Please Install the aiohttp module if you want to make an async request."
-			)
+        async with aiohttp.ClientSession(loop=loop) as session:
+            async with session.get(
+                f"https://bible-api.com/{book}+{chapter}:{verse}"
+            ) as resp:
+                self.request = resp
+                self.json = await resp.json()
 
-		self = cls(book)
-		verse = _build_verse(starting_verse, ending_verse)
+        self.verses = [ChapterVerse(i) for i in self.json["verses"]]
+        self.raw_verse = self.json["text"]
+        if self.request.status == 404:
+            raise NotFound(book, chapter, verse)
+        elif self.request.status > 202:
+            raise ApiError(self.request.status, self.json.get("error", ""))
 
-		async with aiohttp.ClientSession(loop=loop) as session:
-			async with session.get(
-			f"https://bible-api.com/{book}+{chapter}:{verse}"
-			) as resp:
-				self.request = resp
-				self.json = await resp.json()
+        return self
 
-		self.verses = [ChapterVerse(i) for i in self.json["verses"]]
-		self.raw_verse = self.json["text"]
-		if self.request.status == 404:
-			raise NotFound(book, chapter, verse)
-		elif self.request.status > 202:
-			raise ApiError(self.request.status, self.json.get("error", ""))
+    @property
+    def citation(self) -> str:
+        return self.json["reference"]
 
-		return self
-
-	@property
-	def citation(self) -> str:
-		return self.json["reference"]
-
-	@property
-	def translation(self) -> str:
-		return self.json["translation_name"]
+    @property
+    def translation(self) -> str:
+        return self.json["translation_name"]

--- a/hollybooks/quran.py
+++ b/hollybooks/quran.py
@@ -1,23 +1,56 @@
 from typing import Union, Optional
 
-__all__ = ("Surah", "Ayah", "Search", "ApiError", "ContentTypeError", "NumberError", "WrongLang")
+__all__ = (
+    "Surah",
+    "Ayah",
+    "Search",
+    "ApiError",
+    "ContentTypeError",
+    "NumberError",
+    "WrongLang",
+)
+
 
 class ApiError(Exception):
     def __init__(self, status: int, msg: str) -> None:
         super().__init__(f"Api has an error, return code: {status}.\n{msg}")
-	
+
+
 class ContentTypeError(Exception):
-    def __init__(self, class_:str, mode:str, first_query: Optional[Union[str, int]], second_query: Optional[Union[str, int]]) -> None:
-        super().__init__(f"Attempt to decode JSON with unexpected mimetype: Return code: None\nlink: http://api.alquran.cloud/v1/{mode}/{first_query}:{second_query}/en.asad" if class_ == "Ayah" else f"Attempt to decode JSON with unexpected mimetype: Return code: None\nlink: http://api.alquran.cloud/v1/{mode}/{first_query}/{second_query}/en.asad")
+    def __init__(
+        self,
+        class_: str,
+        mode: str,
+        first_query: Optional[Union[str, int]],
+        second_query: Optional[Union[str, int]],
+    ) -> None:
+        super().__init__(
+            f"Attempt to decode JSON with unexpected mimetype: Return code: None\nlink: http://api.alquran.cloud/v1/{mode}/{first_query}:{second_query}/en.asad"
+            if class_ == "Ayah"
+            else f"Attempt to decode JSON with unexpected mimetype: Return code: None\nlink: http://api.alquran.cloud/v1/{mode}/{first_query}/{second_query}/en.asad"
+        )
+
 
 class NumberError(Exception):
-    def __init__(self, mode:int, obj:str, first_query: int, second_query: Optional[Union[str, int]]) -> None:
-        super().__init__(f"{obj} must above {first_query}" if mode == 0 else f"{obj} must be between {first_query} to {second_query}")
+    def __init__(
+        self,
+        mode: int,
+        obj: str,
+        first_query: int,
+        second_query: Optional[Union[str, int]],
+    ) -> None:
+        super().__init__(
+            f"{obj} must above {first_query}"
+            if mode == 0
+            else f"{obj} must be between {first_query} to {second_query}"
+        )
 
 
 class WrongLang(Exception):
-    def __init__(self, lang:str) -> None:
-        super().__init__(f"The lang '{lang}' is not supported, it only support arabic(ar) and english(eng)")
+    def __init__(self, lang: str) -> None:
+        super().__init__(
+            f"The lang '{lang}' is not supported, it only support arabic(ar) and english(eng)"
+        )
 
 
 class Surah:
@@ -25,10 +58,7 @@ class Surah:
         self.surah = surah
 
     @classmethod
-    def request(
-		cls, 
-		surah: int = None
-	):
+    def request(cls, surah: int = None):
         try:
             import requests
         except ImportError:
@@ -44,18 +74,12 @@ class Surah:
         self.data = self.request["data"]
         self.ayah = self.data["ayahs"]
         if self.request["code"] > 202:
-            raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
 
         return self
 
     @classmethod
-    async def async_request(
-		cls, 
-		surah: int = None, *, 
-		loop=None
-	):
+    async def async_request(cls, surah: int = None, *, loop=None):
         try:
             import aiohttp
         except ImportError:
@@ -72,9 +96,7 @@ class Surah:
         self.data = self.request["data"]
         self.ayah = self.data["ayahs"]
         if self.request["code"] > 202:
-            raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
         return self
 
     @property
@@ -114,23 +136,29 @@ class Surah:
         return data
 
     async def ayah_info(
-		self,
-        ayah: int = 1, *,
+        self,
+        ayah: int = 1,
+        *,
         text: bool = True,
         number_in_quran: bool = True,
-		number_in_surah: bool = True,
+        number_in_surah: bool = True,
         juz: bool = True,
         manzil: bool = True,
-		page: bool = True,
-		ruku: bool = True,
-		hizbquarter: bool = True,
-		sajda : bool = True
+        page: bool = True,
+        ruku: bool = True,
+        hizbquarter: bool = True,
+        sajda: bool = True,
     ):
         if ayah <= 0:
             raise NumberError(mode=0, obj="ayah", first_query=1, second_query=None)
 
         elif ayah > int(Surah.request(self.surah).number_ayahs):
-            raise NumberError(mode=1, obj="ayah", first_query=1, second_query=Surah.request(self.surah).number_ayahs)
+            raise NumberError(
+                mode=1,
+                obj="ayah",
+                first_query=1,
+                second_query=Surah.request(self.surah).number_ayahs,
+            )
 
         else:
             ayah -= 1
@@ -144,175 +172,168 @@ class Surah:
                 else None,
                 "juz": self.ayah[ayah]["juz"] if juz else None,
                 "manzil": self.ayah[ayah]["manzil"] if manzil else None,
-				"page": self.ayah[ayah]["page"] if text else None,
-                "ruku": self.ayah[ayah]["ruku"]
-                if number_in_quran
-                else None,
+                "page": self.ayah[ayah]["page"] if text else None,
+                "ruku": self.ayah[ayah]["ruku"] if number_in_quran else None,
                 "hizbquarter": self.ayah[ayah]["hizbQuarter"]
                 if number_in_surah
                 else None,
-                "sajda": self.ayah[ayah]["sajda"] if juz else None
+                "sajda": self.ayah[ayah]["sajda"] if juz else None,
             }
             return data
 
+
 class Ayah:
-	def __init__(self, surah:int=None, *, ayah:int=None):
-		self.surah = surah
-		self.ayah = ayah
+    def __init__(self, surah: int = None, *, ayah: int = None):
+        self.surah = surah
+        self.ayah = ayah
 
-	@classmethod
-	def request(
-		cls, 
-		surah:int=None, *, 
-		ayah:int=None,
-		loop=None
-	):
-		try:
-			import requests
-		except ImportError:
-			raise ImportError(
-		"Please Install the requests module if you want to make a sync request."
-		)
+    @classmethod
+    def request(cls, surah: int = None, *, ayah: int = None, loop=None):
+        try:
+            import requests
+        except ImportError:
+            raise ImportError(
+                "Please Install the requests module if you want to make a sync request."
+            )
 
-		self = cls(surah, ayah=ayah)
-		self.request = requests.get(
-		f"http://api.alquran.cloud/v1/ayah/{surah}:{ayah}/en.asad"
-		).json()
-		self.data = self.request["data"]
-		if self.request["code"] > 202:
-			raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
-		return self
+        self = cls(surah, ayah=ayah)
+        self.request = requests.get(
+            f"http://api.alquran.cloud/v1/ayah/{surah}:{ayah}/en.asad"
+        ).json()
+        self.data = self.request["data"]
+        if self.request["code"] > 202:
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
+        return self
 
-	@classmethod
-	async def async_request(
-		cls, 
-		surah:int=None, *, 
-		ayah:int=None,
-		loop=None
-	):
-		try:
-			import aiohttp
-		except ImportError:
-			raise ImportError(
-				"Please Install the aiohttp module if you want to make an async request."
-			)
+    @classmethod
+    async def async_request(cls, surah: int = None, *, ayah: int = None, loop=None):
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError(
+                "Please Install the aiohttp module if you want to make an async request."
+            )
 
-		self = cls(surah, ayah=ayah)
+        self = cls(surah, ayah=ayah)
 
-		try:
-			async with aiohttp.ClientSession(loop=loop) as session:
-				async with session.get(
-					f"http://api.alquran.cloud/v1/ayah/{surah}:{ayah}/en.asad"
-				) as resp:
-					self.request = await resp.json()
-		except aiohttp.client_exceptions.ContentTypeError:
-			raise ContentTypeError(class_="Ayah", mode='ayah', first_query=surah, second_query=surah)
-		
-		self.data = self.request["data"]
-		if self.request["code"] > 202:
-			raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
-		return self
+        try:
+            async with aiohttp.ClientSession(loop=loop) as session:
+                async with session.get(
+                    f"http://api.alquran.cloud/v1/ayah/{surah}:{ayah}/en.asad"
+                ) as resp:
+                    self.request = await resp.json()
+        except aiohttp.client_exceptions.ContentTypeError:
+            raise ContentTypeError(
+                class_="Ayah", mode="ayah", first_query=surah, second_query=surah
+            )
 
-	@property
-	def api_code(self):
-		return self.request['code']
+        self.data = self.request["data"]
+        if self.request["code"] > 202:
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
+        return self
 
-	@property
-	def api_status(self):
-		return self.request['status']
+    @property
+    def api_code(self):
+        return self.request["code"]
+
+    @property
+    def api_status(self):
+        return self.request["status"]
+
 
 class Search:
-	def __init__(self, mention:str=None, *, surah:Optional[Union[str, int]]=None, request: int=None):
-		self.mention = mention
-		self.surah = surah
-		self.req = request
-	
-	@classmethod
-	async def async_request(
-		cls, 
-		mention:str=None, *, 
-		surah:Optional[Union[str, int]]=None,
-		request:int=None,
-		loop=None
-	):
-		try:
-			import aiohttp
-		except ImportError:
-			raise ImportError(
-				"Please Install the aiohttp module if you want to make an async request."
-			)
+    def __init__(
+        self,
+        mention: str = None,
+        *,
+        surah: Optional[Union[str, int]] = None,
+        request: int = None,
+    ):
+        self.mention = mention
+        self.surah = surah
+        self.req = request
 
+    @classmethod
+    async def async_request(
+        cls,
+        mention: str = None,
+        *,
+        surah: Optional[Union[str, int]] = None,
+        request: int = None,
+        loop=None,
+    ):
+        try:
+            import aiohttp
+        except ImportError:
+            raise ImportError(
+                "Please Install the aiohttp module if you want to make an async request."
+            )
 
-		self = cls(mention, surah=surah, request=request)
+        self = cls(mention, surah=surah, request=request)
 
-		try:
-			async with aiohttp.ClientSession(loop=loop) as session:
-				async with session.get(
-					f"http://api.alquran.cloud/v1/search/{mention}/{surah}/en.pickthall"
-				) as resp:
-					self.request = await resp.json()
-		except aiohttp.client_exceptions.ContentTypeError:
-			raise ContentTypeError(class_="Search", mode='search', first_query=mention, second_query=surah)
-		
-		self.data = self.request["data"]
-		self.matches = self.data['matches']
-		if self.request["code"] > 202:
-			raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
+        try:
+            async with aiohttp.ClientSession(loop=loop) as session:
+                async with session.get(
+                    f"http://api.alquran.cloud/v1/search/{mention}/{surah}/en.pickthall"
+                ) as resp:
+                    self.request = await resp.json()
+        except aiohttp.client_exceptions.ContentTypeError:
+            raise ContentTypeError(
+                class_="Search", mode="search", first_query=mention, second_query=surah
+            )
 
-		return self
+        self.data = self.request["data"]
+        self.matches = self.data["matches"]
+        if self.request["code"] > 202:
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
 
-	@classmethod
-	def request(
-		cls, 
-		mention: str=None, *, 
-		surah: Optional[Union[str, int]]=None,
-		request: int = None
-	):
-		try:
-			import requests
-		except ImportError:
-			raise ImportError(
-		"Please Install the requests module if you want to make a sync request."
-		)
+        return self
 
-		self = cls(mention, surah=surah, request=request)
-		self.request = requests.get(
-		f"http://api.alquran.cloud/v1/search/{mention}/{surah}/en.pickthall"
-		).json()
-		self.data = self.request["data"]
-		self.matches = self.data['matches']
-		if self.request["code"] > 202:
-			raise ApiError(
-				code=self.request['code'], msg=self.request['data']
-			)
-		return self
-		
-	@property
-	def count(self):
-		return self.data['count']
+    @classmethod
+    def request(
+        cls,
+        mention: str = None,
+        *,
+        surah: Optional[Union[str, int]] = None,
+        request: int = None,
+    ):
+        try:
+            import requests
+        except ImportError:
+            raise ImportError(
+                "Please Install the requests module if you want to make a sync request."
+            )
 
-	@property
-	def api_code(self):
-		return self.request['code']
+        self = cls(mention, surah=surah, request=request)
+        self.request = requests.get(
+            f"http://api.alquran.cloud/v1/search/{mention}/{surah}/en.pickthall"
+        ).json()
+        self.data = self.request["data"]
+        self.matches = self.data["matches"]
+        if self.request["code"] > 202:
+            raise ApiError(code=self.request["code"], msg=self.request["data"])
+        return self
 
-	@property
-	def api_status(self):
-		return self.request['status']
+    @property
+    def count(self):
+        return self.data["count"]
 
-	def find(self):
-		data=[]
-		if self.req == None:
-			for num in range(self.data['count']):
-				data.append(self.matches[num]['text'])
-			return data
+    @property
+    def api_code(self):
+        return self.request["code"]
 
-		else:	
-			for num in range(self.req):
-				data.append(self.matches[num]['text'])
-			return data
+    @property
+    def api_status(self):
+        return self.request["status"]
+
+    def find(self):
+        data = []
+        if self.req == None:
+            for num in range(self.data["count"]):
+                data.append(self.matches[num]["text"])
+            return data
+
+        else:
+            for num in range(self.req):
+                data.append(self.matches[num]["text"])
+            return data

--- a/hollybooks/torah.py
+++ b/hollybooks/torah.py
@@ -1,130 +1,87 @@
-__all__ = ("ApiError", "NotFound", "ChapterVerse", "Chapter", "BibleOnly")
+from .bible import Bible
+
+
+__all__ = ("ApiError", "NotFound", "Torah", "BibleOnly")
 
 
 class ApiError(Exception):
-	def __init__(self, status: int, msg: str) -> None:
-		super().__init__(f"Api has an error, return code: {status}.\n{msg}")
+    def __init__(self, status: int, msg: str) -> None:
+        super().__init__(f"Api has an error, return code: {status}.\n{msg}")
 
 
 class NotFound(Exception):
-	def __init__(self, book: str, chapter: int, verse: str) -> None:
-		super().__init__(
-			f"Book {book}, Chapter {chapter}, Verse(s) {verse} Wasn't Found."
-		)
+    def __init__(self, book: str, chapter: int, verse: str) -> None:
+        super().__init__(
+            f"Book {book}, Chapter {chapter}, Verse(s) {verse} Wasn't Found."
+        )
+
 
 class BibleOnly(Exception):
-	def __init__(self, book: str) -> None:
-		super().__init__(
-			f"The book {book} wasn't found because its available only in Bible"
-		)
-
-def _build_verse(start: int, end: int = None) -> str:
-	return f"{start}{f'-{end}' if end else ''}"
+    def __init__(self, book: str) -> None:
+        super().__init__(
+            f"The book {book} wasn't found because its available only in Bible"
+        )
 
 
-def _build_citation(book: str, chapter: int, verse: str) -> str:
-	return f"{book} {chapter}:{verse}"
+class Torah(Bible):
+    def __init__(self, book: str) -> None:
+        super().__init__(book)
 
+    @classmethod
+    def request(
+        cls, book: str, *, chapter: int, starting_verse: int, ending_verse: int = None
+    ):
+        if book.lower() not in [
+            "genesis",
+            "exodus",
+            "leviticus",
+            "numbers",
+            "deuteronomy",
+        ]:
+            raise BibleOnly(book)
 
-class ChapterVerse:
-	def __init__(self, verse: dict) -> None:
-		del verse["book_id"]
+        self = super(Torah, cls).request(
+            book,
+            chapter=chapter,
+            starting_verse=starting_verse,
+            ending_verse=ending_verse,
+        )
 
-		for key, val in verse.items():
-			setattr(self, key, val)
+        return self
 
-	def __str__(self) -> str:
-		return self.text
+    @classmethod
+    async def async_request(
+        cls,
+        book: str,
+        *,
+        chapter: int,
+        starting_verse: int,
+        ending_verse: int = None,
+        loop=None,
+    ):
+        if book.lower() not in [
+            "genesis",
+            "exodus",
+            "leviticus",
+            "numbers",
+            "deuteronomy",
+        ]:
+            raise BibleOnly(book)
 
-	@property
-	def citation(self) -> str:
-		return _build_citation(self.book_name, self.chapter, self.verse)
+        self = await super(Torah, cls).async_request(
+            book,
+            chapter=chapter,
+            starting_verse=starting_verse,
+            ending_verse=ending_verse,
+            loop=loop,
+        )
 
+        return self
 
-class Chapter:
-	def __init__(self, book: str) -> None:
-		self.book = book
+    @property
+    def citation(self) -> str:
+        return self.json["reference"]
 
-	@classmethod
-	def request(
-		cls, 
-		book: str, 
-		*, 
-		chapter: int, 
-		starting_verse: int, 
-		ending_verse: int = None
-	):
-		if book.lower() not in ['genesis', 'exodus', 'leviticus', 'numbers', 'deuteronomy']:
-			raise BibleOnly(book)
-
-		try:
-			import requests
-		except ImportError:
-			raise ImportError(
-				"Please Install the requests module if you want to make a sync request."
-			)
-
-		self = cls(book)
-		verse = _build_verse(starting_verse, ending_verse)
-
-		self.request = requests.get(
-		f"https://bible-api.com/{book}+{chapter}:{verse}"
-		)
-		if self.request.status_code == 404:
-			raise NotFound(book, chapter, verse)
-		elif self.request.status_code > 202:
-			raise ApiError(
-				self.request.status_code, self.request.json().get("error", "")
-			)
-
-		self.json = self.request.json()
-		self.verses = [ChapterVerse(i) for i in self.json["verses"]]
-
-		return self
-
-	@classmethod
-	async def async_request(
-		cls,
-		book: str,
-		*,
-		chapter: int,
-		starting_verse: int,
-		ending_verse: int = None,
-		loop=None,
-	):
-		if book.lower() not in ['genesis', 'exodus', 'leviticus', 'numbers', 'deuteronomy']:
-			raise BibleOnly(book)
-
-		try:
-			import aiohttp
-		except ImportError:
-			raise ImportError(
-				"Please Install the aiohttp module if you want to make an async request."
-			)
-
-		self = cls(book)
-		verse = _build_verse(starting_verse, ending_verse)
-
-		async with aiohttp.ClientSession(loop=loop) as session:
-			async with session.get(
-			f"https://bible-api.com/{book}+{chapter}:{verse}"
-			) as resp:
-				self.request = resp
-				self.json = await resp.json()
-
-		self.verses = [ChapterVerse(i) for i in self.json["verses"]]
-		self.raw_verse = self.json["text"]
-		if self.request.status == 404:
-			raise NotFound(book, chapter, verse)
-		elif self.request.status > 202:
-			raise ApiError(self.request.status, self.json.get("error", ""))
-
-		return self
-
-	@property
-	def citation(self) -> str:
-		return self.json["reference"]
-
-	@property
-	def translation(self) -> str:
-		return self.json["translation_name"]
+    @property
+    def translation(self) -> str:
+        return self.json["translation_name"]


### PR DESCRIPTION
**PR Additions**
No additions this time!

**PR Changes**
- Changed the name of the Chapter class of `torah.py` to Torah and the name of the Chapter class of `bible.py` to Bible
- Made the Torah class subclass the Bible class (which shortened the code by 43 lines)
- Updated README (it had false examples)
- Formatted all Python files using [black](https://pypi.org/project/black)

**PR Deprecations**
- The if-statement on `Bible.request` and `Bible.async_request` that disallows the five books of Moses to be accessed from the Bible class
- TorahOnly exception, it's deemed useless after deprecating the omission of the five books of Moses to be accessed from the Bible class
- ChapterVerse class from `torah.py`, you can just use the exact same class from `bible.py`